### PR TITLE
◽️新規スクラム追加時の情報不足制御、詳細編集時の重複アイテムの制御

### DIFF
--- a/Scrumdinger/View/DetailEditView.swift
+++ b/Scrumdinger/View/DetailEditView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct DetailEditView: View {
     @Binding var scrum: DailyScrum
     @State private var newAttendeeName = ""
+    @State private var isPresenting: Bool = false
+    
     var body: some View {
         Form {
             Section(header: Text("Meeting Info")) {
@@ -37,8 +39,16 @@ struct DetailEditView: View {
                     Button(action: {
                         withAnimation {
                             let attendee = DailyScrum.Attendee(name: newAttendeeName)
-                            scrum.attendees.append(attendee)
-                            newAttendeeName = ""
+                            let attendees = scrum.attendees
+                            if attendees.count > 0 {
+//                                ForEach(attendees) { attendee in
+//                                    if attendee.name == newAttendeeName { isPresenting = true }
+//                                }
+                            }
+                            if !isPresenting {
+                                scrum.attendees.append(attendee)
+                                newAttendeeName = ""
+                            }
                         }
                     }) {
                         Image(systemName: "plus.circle.fill")
@@ -46,6 +56,14 @@ struct DetailEditView: View {
                     }
                     .disabled(newAttendeeName.isEmpty)
                 }
+            }
+            .alert("", isPresented: $isPresenting) {
+                Button("OK") {
+                    isPresenting = false
+                    newAttendeeName = ""
+                }
+            } message: {
+                Text("attendee name of \"\(newAttendeeName)\" what already exsits")
             }
         }
     }

--- a/Scrumdinger/View/DetailEditView.swift
+++ b/Scrumdinger/View/DetailEditView.swift
@@ -41,9 +41,9 @@ struct DetailEditView: View {
                             let attendee = DailyScrum.Attendee(name: newAttendeeName)
                             let attendees = scrum.attendees
                             if attendees.count > 0 {
-//                                ForEach(attendees) { attendee in
-//                                    if attendee.name == newAttendeeName { isPresenting = true }
-//                                }
+                                for attendee in attendees {
+                                    if attendee.name == newAttendeeName { isPresenting = true }
+                                }
                             }
                             if !isPresenting {
                                 scrum.attendees.append(attendee)
@@ -63,7 +63,7 @@ struct DetailEditView: View {
                     newAttendeeName = ""
                 }
             } message: {
-                Text("attendee name of \"\(newAttendeeName)\" what already exsits")
+                Text("attendee name of \"\(newAttendeeName)\" already exsits")
             }
         }
     }

--- a/Scrumdinger/View/NewScrumSheet.swift
+++ b/Scrumdinger/View/NewScrumSheet.swift
@@ -49,7 +49,7 @@ struct NewScrumSheet: View {
                     case .titleEmpty:
                         Text("input any title")
                     case .titleDuplicated:
-                        Text("title of \"\(newScrum.title)\" what already exsits")
+                        Text("title of \"\(newScrum.title)\" already exsits")
                     case .attendeesNotEnough:
                         Text("You need more attendees. Do not be lonely...")
                     default:
@@ -63,9 +63,9 @@ struct NewScrumSheet: View {
         isPresentingAlertDialog = false
         
         if newScrum.attendees.count < 2 { controlState = .attendeesNotEnough }
-//        ForEach(scrums) { scrum in
-//            if scrum.title == newScrum.title { controlState = .titleDuplicated }
-//        }
+        for scrum in scrums {
+            if scrum.title == newScrum.title { controlState = .titleDuplicated }
+        }
         if newScrum.title.isEmpty { controlState = .titleEmpty }
         
         if controlState != .defaultState { isPresentingAlertDialog = true }

--- a/Scrumdinger/View/NewScrumSheet.swift
+++ b/Scrumdinger/View/NewScrumSheet.swift
@@ -11,6 +11,15 @@ struct NewScrumSheet: View {
     @State private var newScrum = DailyScrum.emptyScrum
     @Binding var scrums: [DailyScrum]
     @Binding var isPresentingNewScrumView: Bool
+    @State private var controlState: ControlState = .defaultState
+    @State private var isPresentingAlertDialog = false
+    
+    enum ControlState {
+        case titleEmpty
+        case titleDuplicated
+        case attendeesNotEnough
+        case defaultState
+    }
     
     var body: some View {
         NavigationStack {
@@ -23,12 +32,43 @@ struct NewScrumSheet: View {
                     }
                     ToolbarItem(placement: .confirmationAction) {
                         Button("Add") {
-                            scrums.append(newScrum)
-                            isPresentingNewScrumView = false
+                            checkInputInfo()
+                            if !isPresentingAlertDialog {
+                                scrums.append(newScrum)
+                                isPresentingNewScrumView = false
+                            }
                         }
                     }
                 }
+                .alert("", isPresented: $isPresentingAlertDialog) {
+                    Button("OK") {
+                        controlState = .defaultState
+                    }
+                } message: {
+                    switch controlState {
+                    case .titleEmpty:
+                        Text("input any title")
+                    case .titleDuplicated:
+                        Text("title of \"\(newScrum.title)\" what already exsits")
+                    case .attendeesNotEnough:
+                        Text("You need more attendees. Do not be lonely...")
+                    default:
+                        Text("")
+                    }
+                }
         }
+    }
+    
+    private func checkInputInfo() {
+        isPresentingAlertDialog = false
+        
+        if newScrum.attendees.count < 2 { controlState = .attendeesNotEnough }
+//        ForEach(scrums) { scrum in
+//            if scrum.title == newScrum.title { controlState = .titleDuplicated }
+//        }
+        if newScrum.title.isEmpty { controlState = .titleEmpty }
+        
+        if controlState != .defaultState { isPresentingAlertDialog = true }
     }
 }
 


### PR DESCRIPTION
・ダイアログ表示でアイテムの追加を制御
・タイトルなし
・参加者が2人未満
・リストに存在するタイトルとの重複
・参加者の名前の重複