### PR TITLE
◽️詳細画面で参加者の順番をランダムに並べ替える機能の実装

### DIFF
--- a/Scrumdinger/View/DetailEditView.swift
+++ b/Scrumdinger/View/DetailEditView.swift
@@ -27,11 +27,16 @@ struct DetailEditView: View {
             }
             Section(header: Text("Attendees")) {
                 ForEach(scrum.attendees) { attendee in
-                    Text(attendee.name)
+                    HStack {
+                        Text(attendee.name)
+                        Spacer()
+                        Image(systemName: "equal")
+                    }
                 }
                 .onDelete { indices in
                     scrum.attendees.remove(atOffsets: indices)
                 }
+                .onMove(perform: moveRow)
                 HStack {
                     TextField("New Attendee", text: $newAttendeeName)
                     Button(action: {
@@ -49,6 +54,11 @@ struct DetailEditView: View {
             }
         }
     }
+    
+    private func moveRow(from source: IndexSet, to destination: Int) {
+        scrum.attendees.move(fromOffsets: source, toOffset: destination)
+    }
+    
 }
 
 struct DetailEditView_Previews: PreviewProvider {

--- a/Scrumdinger/View/DetailView.swift
+++ b/Scrumdinger/View/DetailView.swift
@@ -11,7 +11,8 @@ struct DetailView: View {
     @Binding var scrum: DailyScrum
     
     @State private var editingScrum = DailyScrum.emptyScrum
-    @State private var isPressingEditView = false
+    @State private var isPresentingEditView = false
+    @State private var isPresentingConfirmDialog = false
     
     var body: some View {
         List {
@@ -38,11 +39,13 @@ struct DetailView: View {
                 }
                 .accessibilityElement(children: .combine)
             }
-            Section(header: Text("Attendees")) {
+            .textCase(.none)
+            Section(header: headerView()) {
                 ForEach(scrum.attendees) { attendee in
                     Label(attendee.name, systemImage: "person")
                 }
             }
+            .textCase(.none)
             Section(header: Text("History")) {
                 if scrum.history.isEmpty {
                     Label("No meetings yet", systemImage: "calendar.badge.exclamationmark")
@@ -56,33 +59,61 @@ struct DetailView: View {
                     }
                 }
             }
+            .textCase(.none)
         }
         .navigationTitle(scrum.title)
         .toolbar {
             Button("Edit") {
-                isPressingEditView = true
+                isPresentingEditView = true
                 editingScrum = scrum
             }
         }
-        .sheet(isPresented: $isPressingEditView) {
+        .sheet(isPresented: $isPresentingEditView) {
             NavigationStack {
                 DetailEditView(scrum: $editingScrum)
                     .navigationTitle(scrum.title)
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
                             Button("Cancel") {
-                                isPressingEditView = false
+                                isPresentingEditView = false
                             }
                         }
                         ToolbarItem(placement: .confirmationAction) {
                             Button("Done") {
-                                isPressingEditView = false
+                                isPresentingEditView = false
                                 scrum = editingScrum
                             }
                         }
                     }
             }
         }
+        .alert("Confirm", isPresented: $isPresentingConfirmDialog) {
+            Button("OK") {
+                scrum.attendees.shuffle()
+                isPresentingConfirmDialog = false
+            }
+            Button("Cancel") {
+                isPresentingConfirmDialog = false
+            }
+        } message: {
+            Text("Would you like to sort attendee members randomly?")
+        }
+    }
+    
+    private func headerView() -> some View {
+        HStack {
+            Text("Attendees")
+            Spacer()
+            Button(action: {
+                isPresentingConfirmDialog = true
+            }) {
+                Image(systemName: "shuffle")
+            }
+            .padding(4)
+            .background()
+            .cornerRadius(4)
+        }
+
     }
 }
 


### PR DESCRIPTION
・参加者セクションのタイトル横にボタンの配置
・ボタン押下時に確認ダイアログの表示
・OKボタン押下後に参加者配列をシャッフルする
・詳細編集画面でリストアイテムのドラッグ移動の実装